### PR TITLE
Sync paket.dependencies and paket.lock with regard

### DIFF
--- a/paket.lock
+++ b/paket.lock
@@ -23,7 +23,7 @@ NUGET
       Microsoft.Owin.FileSystems (>= 3.0.1)
       Owin (>= 1.0)
     Owin (1.0)
-    RazorEngine (3.5.3)
+    RazorEngine (3.6.6)
       Microsoft.AspNet.Razor (>= 3.0.0) - >= net45
       Microsoft.AspNet.Razor (2.0.30506.0) - >= net40 < net45
     Zlib.Portable (1.10.0)


### PR DESCRIPTION
to RazorEngine version increase from 3.5.3 to 3.6.6
